### PR TITLE
Better webpacker support

### DIFF
--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -21,7 +21,7 @@ class LanguagePack::Cache
     return false if !target.exist?
 
     # Get the size of target in kb
-    target_size = `du -sk #{target}`.first
+    target_size = `du -sk #{target}`.split.first
     return false if size.nil?
 
     if target_size * 1024 > size

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -22,8 +22,9 @@ class LanguagePack::Cache
 
     # Get the size of target in kb
     target_size = `du -sk #{target}`.split.first
-    return false if size.nil?
+    return false if target_size.nil?
 
+    target_size = target_size.to_i
     if target_size * 1024 > size
       clear(path)
       return true

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -54,6 +54,8 @@ class LanguagePack::Cache
     return false unless File.exist?(from)
     FileUtils.mkdir_p File.dirname(to)
     puts "----------------- copying files ----------------"
+    puts "PWD #{`pwd`}"
+    puts "Base: #{@cache_base}"
     puts "From: #{from}"
     puts "To: #{to}"
     puts "------------------------------------------------"

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -18,7 +18,7 @@ class LanguagePack::Cache
   # removes the path from cache if it's bigger than size
   def clear_if_oversize(path, size)
     target = (@cache_base + path)
-    return false if !target.exists?
+    return false if !target.exist?
 
     # Get the size of target in kb
     target_size = `du -sk #{target}`.first

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -53,6 +53,10 @@ class LanguagePack::Cache
   def copy(from, to, options='-a')
     return false unless File.exist?(from)
     FileUtils.mkdir_p File.dirname(to)
+    puts "----------------- copying files ----------------"
+    puts "From: #{from}"
+    puts "To: #{to}"
+    puts "------------------------------------------------"
     system("cp #{options} #{from}/. #{to}")
   end
 

--- a/lib/language_pack/cache.rb
+++ b/lib/language_pack/cache.rb
@@ -15,6 +15,23 @@ class LanguagePack::Cache
     target.exist? && target.rmtree
   end
 
+  # removes the path from cache if it's bigger than size
+  def clear_if_oversize(path, size)
+    target = (@cache_base + path)
+    return false if !target.exists?
+
+    # Get the size of target in kb
+    target_size = `du -sk #{target}`.first
+    return false if size.nil?
+
+    if target_size * 1024 > size
+      clear(path)
+      return true
+    end
+
+    false
+  end
+
   # Overwrite cache contents
   # When called the cache destination will be cleared and the new contents coppied over
   # This method is perferable as LanguagePack::Cache#add can cause accidental cache bloat.
@@ -53,12 +70,6 @@ class LanguagePack::Cache
   def copy(from, to, options='-a')
     return false unless File.exist?(from)
     FileUtils.mkdir_p File.dirname(to)
-    puts "----------------- copying files ----------------"
-    puts "PWD #{`pwd`}"
-    puts "Base: #{@cache_base}"
-    puts "From: #{from}"
-    puts "To: #{to}"
-    puts "------------------------------------------------"
     system("cp #{options} #{from}/. #{to}")
   end
 

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -1,6 +1,8 @@
 require 'json'
+require "language_pack/shell_helpers"
 
 class LanguagePack::Helpers::Nodebin
+
   URL = "https://nodebin.herokai.com/v1/"
 
   def self.query(q)
@@ -10,20 +12,32 @@ class LanguagePack::Helpers::Nodebin
     end
   end
 
-  def self.hardcoded_node_lts
-    version = "8.9.4"
+  def self.hardcoded_node_lts(version = nil)
+    version ||= '8.9.4'
     {
       "number" => version,
       "url"    => "https://s3pository.heroku.com/node/v#{version}/node-v#{version}-linux-x64.tar.gz"
     }
   end
 
-  def self.hardcoded_yarn
-    version = "1.3.2"
+  def self.hardcoded_yarn(version = nil)
+    version ||= '1.3.2'
     {
       "number" => version,
       "url"    => "https://yarnpkg.com/downloads/#{version}/yarn-v#{version}.tar.gz"
     }
+  end
+
+  def self.detected_versions
+    return @detected_versions if defined? @detected_versions
+
+    @detected_versions = {}
+    if File.exists? 'package.json'
+      package = JSON.parse(File.read('package.json'))
+      engines = package['engines']
+      @detected_versions.merge!(engines) if !engines.empty?
+    end
+    @detected_versions
   end
 
   def self.node(q)
@@ -31,10 +45,12 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.node_lts
-    hardcoded_node_lts # node("latest?range=6.x")
+    version = detected_versions['node']
+    hardcoded_node_lts(version) # node("latest?range=6.x")
   end
 
   def self.yarn(q)
-    hardcoded_yarn # query("yarn/linux-x64/#{q}")
+    version = detected_versions['yarn']
+    hardcoded_yarn(version) # query("yarn/linux-x64/#{q}")
   end
 end

--- a/lib/language_pack/helpers/nodebin.rb
+++ b/lib/language_pack/helpers/nodebin.rb
@@ -11,7 +11,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_node_lts
-    version = "6.11.1"
+    version = "8.9.4"
     {
       "number" => version,
       "url"    => "https://s3pository.heroku.com/node/v#{version}/node-v#{version}-linux-x64.tar.gz"
@@ -19,7 +19,7 @@ class LanguagePack::Helpers::Nodebin
   end
 
   def self.hardcoded_yarn
-    version = "1.0.2"
+    version = "1.3.2"
     {
       "number" => version,
       "url"    => "https://yarnpkg.com/downloads/#{version}/yarn-v#{version}.tar.gz"

--- a/lib/language_pack/helpers/stale_file_cleaner.rb
+++ b/lib/language_pack/helpers/stale_file_cleaner.rb
@@ -11,7 +11,9 @@ class LanguagePack::Helpers::StaleFileCleaner
   end
 
   def glob
-    "#{@dir}/**/*"
+    dir = @dir
+    dir = "{#{dir.join(',')}}" if Array === dir
+    "#{dir}/**/*"
   end
 
   def files

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -3,7 +3,8 @@ require "language_pack/rails3"
 
 # Rails 4 Language Pack. This is for all Rails 4.x apps.
 class LanguagePack::Rails4 < LanguagePack::Rails3
-  ASSETS_CACHE_LIMIT = 52428800 # bytes
+  ASSETS_CACHE_LIMIT = 52428800         # in bytes, 50M
+  ASSETS_FILES_CACHE_LIMIT = 104857600  # in bytes, 100M
 
   # detects if this is a Rails 4.x app
   # @return [Boolean] true if it's a Rails 4.x app
@@ -98,7 +99,7 @@ WARNING
   end
 
   def clear_assets_if_oversize
-    topic('Cleared cached assets') if @cache.clear_if_oversize(public_assets_folder, 1024)
+    topic('Cleared cached assets') if @cache.clear_if_oversize(public_assets_folder, ASSETS_FILES_CACHE_LIMIT)
   end
 
   def load_assets_cache

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -79,7 +79,7 @@ WARNING
 
         topic("Preparing app for Rails asset pipeline")
 
-        clear_assets_cache_if_oversize
+        clear_assets_if_oversize
         load_assets_cache
 
         precompile.invoke(env: rake_env)

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -79,8 +79,7 @@ WARNING
 
         topic("Preparing app for Rails asset pipeline")
 
-        @cache.load_without_overwrite public_assets_folder
-        @cache.load default_assets_cache
+        load_assets_cache
 
         precompile.invoke(env: rake_env)
 
@@ -92,13 +91,22 @@ WARNING
           rake.task("assets:clean").invoke(env: rake_env)
 
           cleanup_assets_cache
-          @cache.store public_assets_folder
-          @cache.store default_assets_cache
+          save_assets_cache
         else
           precompile_fail(precompile.output)
         end
       end
     end
+  end
+
+  def load_assets_cache
+    @cache.load_without_overwrite public_assets_folder
+    @cache.load default_assets_cache
+  end
+
+  def save_assets_cache
+    @cache.store public_assets_folder
+    @cache.store default_assets_cache
   end
 
   def cleanup_assets_cache

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -79,6 +79,7 @@ WARNING
 
         topic("Preparing app for Rails asset pipeline")
 
+        clear_assets_cache_if_oversize
         load_assets_cache
 
         precompile.invoke(env: rake_env)
@@ -87,9 +88,6 @@ WARNING
           log "assets_precompile", :status => "success"
           puts "Asset precompilation completed (#{"%.2f" % precompile.time}s)"
 
-          puts "Cleaning assets"
-          rake.task("assets:clean").invoke(env: rake_env)
-
           cleanup_assets_cache
           save_assets_cache
         else
@@ -97,6 +95,10 @@ WARNING
         end
       end
     end
+  end
+
+  def clear_assets_if_oversize
+    topic('Cleared cached assets') if @cache.clear_if_oversize(public_assets_folder, 1024)
   end
 
   def load_assets_cache

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -3,8 +3,8 @@ require "language_pack/rails3"
 
 # Rails 4 Language Pack. This is for all Rails 4.x apps.
 class LanguagePack::Rails4 < LanguagePack::Rails3
-  ASSETS_CACHE_LIMIT = 52428800         # in bytes, 50M
-  ASSETS_FILES_CACHE_LIMIT = 104857600  # in bytes, 100M
+  ASSETS_CACHE_LIMIT = 104857600         # in bytes, 100M
+  ASSETS_FILES_CACHE_LIMIT = 104857600   # in bytes, 100M
 
   # detects if this is a Rails 4.x app
   # @return [Boolean] true if it's a Rails 4.x app

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -59,8 +59,10 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
 
   def cleanup_assets_cache
     instrument "rails5.cleanup_assets_cache" do
-      LanguagePack::Helpers::StaleFileCleaner.new(webpacker_assets_cache).clean_over(ASSETS_CACHE_LIMIT)
-      LanguagePack::Helpers::StaleFileCleaner.new(default_assets_cache).clean_over(ASSETS_CACHE_LIMIT)
+      LanguagePack::Helpers::StaleFileCleaner.new([
+        webpacker_assets_cache,
+        default_assets_cache
+      ]).clean_over(ASSETS_CACHE_LIMIT)
     end
   end
 end

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -3,6 +3,9 @@ require "language_pack"
 require "language_pack/rails42"
 
 class LanguagePack::Rails5 < LanguagePack::Rails42
+  WEBPACK_FILES_CACHE_LIMIT = 104857600   # in bytes, 100M
+  NODE_MODULES_CACHE_LIMIT = 314572800    # in bytes, 300M
+
   # @return [Boolean] true if it's a Rails 5.x app
   def self.use?
     instrument "rails5.use" do
@@ -59,7 +62,8 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
 
   def clear_assets_if_oversize
     super
-    topic('Cleared cached packs') if @cache.clear_if_oversize(webpacker_assets_folder, 1024)
+    topic('Cleared cached packs.') if @cache.clear_if_oversize(webpacker_assets_folder, WEBPACK_FILES_CACHE_LIMIT)
+    topic('Cleared cached node modules.') if @cache.clear_if_oversize(webpacker_bundles, 1024)
   end
 
   def cleanup_assets_cache

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -27,7 +27,27 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
     })
   end
 
+  def webpacker_assets_folder
+    "public/packs"
+  end
+
+  def webpacker_assets_cache
+    "tmp/cache/webpacker"
+  end
+
   def install_plugins
     # do not install plugins, do not call super, do not warn
+  end
+
+  def load_assets_cache
+    super
+    @cache.load_without_overwrite webpacker_assets_folder
+    @cache.load webpacker_assets_folder
+  end
+
+  def save_assets_cache
+    super
+    @cache.store webpacker_assets_folder
+    @cache.store webpacker_assets_cache
   end
 end

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -57,6 +57,11 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
     @cache.store webpacker_assets_cache
   end
 
+  def clear_assets_if_oversize
+    super
+    topic('Cleared cached packs') if @cache.clear_if_oversize(webpacker_assets_folder, 1024)
+  end
+
   def cleanup_assets_cache
     instrument "rails5.cleanup_assets_cache" do
       LanguagePack::Helpers::StaleFileCleaner.new([

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -56,4 +56,11 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
     @cache.store webpacker_assets_folder
     @cache.store webpacker_assets_cache
   end
+
+  def cleanup_assets_cache
+    instrument "rails5.cleanup_assets_cache" do
+      LanguagePack::Helpers::StaleFileCleaner.new(webpacker_assets_cache).clean_over(ASSETS_CACHE_LIMIT)
+      LanguagePack::Helpers::StaleFileCleaner.new(default_assets_cache).clean_over(ASSETS_CACHE_LIMIT)
+    end
+  end
 end

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -35,6 +35,10 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
     "tmp/cache/webpacker"
   end
 
+  def webpacker_bundles
+    "node_modules"
+  end
+
   def install_plugins
     # do not install plugins, do not call super, do not warn
   end
@@ -42,11 +46,13 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
   def load_assets_cache
     super
     @cache.load_without_overwrite webpacker_assets_folder
-    @cache.load webpacker_assets_folder
+    @cache.load webpacker_assets_cache
+    @cache.load_without_overwrite webpacker_bundles
   end
 
   def save_assets_cache
     super
+    @cache.store webpacker_bundles
     @cache.store webpacker_assets_folder
     @cache.store webpacker_assets_cache
   end

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -63,7 +63,7 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
   def clear_assets_if_oversize
     super
     topic('Cleared cached packs.') if @cache.clear_if_oversize(webpacker_assets_folder, WEBPACK_FILES_CACHE_LIMIT)
-    topic('Cleared cached node modules.') if @cache.clear_if_oversize(webpacker_bundles, 1024)
+    topic('Cleared cached node modules.') if @cache.clear_if_oversize(webpacker_bundles, NODE_MODULES_CACHE_LIMIT)
   end
 
   def cleanup_assets_cache


### PR DESCRIPTION
- Cache webpack assets and node modules. 
- Removed assets:clean at the end because it doesn't work for webpacker. Instead, the cache will be cleared once it reached a hardcoded size limit. 